### PR TITLE
Fix asset enqueuing

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,0 +1,3 @@
+jQuery(document).ready(function ($) {
+  $('.sortable').sortable();
+});

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+= 2.0.5 =
+* Fixed asset enqueuing
+
+= 2.0.4 =
+
 = 2.0.3 =
 
 * Really add Telegram

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Seags
 Tags: social, social bookmarks, social links, social networking
 Requires at least: 4.8
 Tested up to: 5.4
-Stable tag: 2.0.4
+Stable tag: 2.0.5
 Requires PHP: 5.6
 License: GPL2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -81,6 +81,12 @@ You can change the order on your settings page.
 2. Default Social Links
 
 == Changelog ==
+
+= 2.0.5 =
+
+* Fix asset enqueuing
+
+= 2.0.4 =
 
 = 2.0.3 =
 

--- a/src/boot.php
+++ b/src/boot.php
@@ -21,6 +21,7 @@ function boot() {
 			register_widget( 'SeagynDavis\TheSocialLinks\Widget\Links' );
 		}
 	);
+	add_action( 'wp_enqueue_scripts', 'SeagynDavis\TheSocialLinks\enqueue_styles' );
 
 	/**
 	 * Admin related hooks
@@ -46,28 +47,45 @@ function boot() {
 	);
 	add_filter( 'plugin_action_links', 'SeagynDavis\TheSocialLinks\Admin\action_links', 10, 2 );
 
-	add_action( 'admin_enqueue_scripts', 'SeagynDavis\TheSocialLinks\enqueue_admin_scripts' );
+	add_action( 'admin_enqueue_scripts', 'SeagynDavis\TheSocialLinks\enqueue_scripts' );
+	add_action( 'admin_enqueue_scripts', 'SeagynDavis\TheSocialLinks\enqueue_styles' );
 }
 
 /**
- * Enqueue scripts needed for the admin page.
+ * Enqueue front end and admin styles.
  */
-function enqueue_admin_scripts() {
-	wp_enqueue_script( 'jquery-ui-sortable', null, [ 'jquery' ], THE_SOCIAL_LINKS_VERSION, true );
-	wp_enqueue_style( 'font-awesome', THE_SOCIAL_LINKS_URL . 'assets/css/fontawesome.min.css', [], THE_SOCIAL_LINKS_VERSION );
-	wp_enqueue_style( 'font-awesome-brands', THE_SOCIAL_LINKS_URL . 'assets/css/brands.min.css', [ 'font-awesome' ], THE_SOCIAL_LINKS_VERSION );
-	wp_enqueue_style( 'font-awesome-solid', THE_SOCIAL_LINKS_URL . 'assets/css/solid.min.css', [ 'font-awesome' ], THE_SOCIAL_LINKS_VERSION );
+function enqueue_styles() {
+	wp_enqueue_style( 'tsl-font-awesome', THE_SOCIAL_LINKS_URL . 'assets/css/fontawesome.min.css', [], THE_SOCIAL_LINKS_VERSION );
+	wp_enqueue_style( 'tsl-font-awesome-brands', THE_SOCIAL_LINKS_URL . 'assets/css/brands.min.css', [ 'tsl-font-awesome' ], THE_SOCIAL_LINKS_VERSION );
+	wp_enqueue_style( 'tsl-font-awesome-solid', THE_SOCIAL_LINKS_URL . 'assets/css/solid.min.css', [ 'tsl-font-awesome' ], THE_SOCIAL_LINKS_VERSION );
 	wp_enqueue_style( 'the-social-links', THE_SOCIAL_LINKS_URL . 'assets/css/style.css', [], THE_SOCIAL_LINKS_VERSION );
 }
 
 /**
- * Enqueue scripts needed for the admin page.
+ * Enqueue admin scripts.
  */
-function enqueue_public_scripts() {
-	wp_enqueue_style( 'font-awesome', THE_SOCIAL_LINKS_URL . 'assets/css/fontawesome.min.css', [], THE_SOCIAL_LINKS_VERSION );
-	wp_enqueue_style( 'font-awesome-brands', THE_SOCIAL_LINKS_URL . 'assets/css/brands.min.css', [ 'font-awesome' ], THE_SOCIAL_LINKS_VERSION );
-	wp_enqueue_style( 'font-awesome-solid', THE_SOCIAL_LINKS_URL . 'assets/css/solid.min.css', [ 'font-awesome' ], THE_SOCIAL_LINKS_VERSION );
-	wp_enqueue_style( 'the-social-links', THE_SOCIAL_LINKS_URL . 'assets/css/style.css', [], THE_SOCIAL_LINKS_VERSION );
+function enqueue_scripts() {
+  if ( is_settings_page() ) {
+    wp_enqueue_script( 'the-social-links', THE_SOCIAL_LINKS_URL . 'assets/js/admin.js', [ 'jquery-ui-sortable' ], THE_SOCIAL_LINKS_VERSION, true );
+  }
+}
+
+/**
+ * Checks if the settings page is the current page.
+ *
+ * @return bool
+ */
+function is_settings_page() {
+  $current_screen   = get_current_screen();
+  $is_settings_page = false;
+
+  if ( null !== $current_screen ) {
+    if ( 'toplevel_page_the-social-links' === $current_screen->id ) {
+      $is_settings_page = true;
+    }
+  }
+
+  return $is_settings_page;
 }
 
 /**

--- a/src/html/admin.php
+++ b/src/html/admin.php
@@ -210,9 +210,3 @@ $social_networks = get_social_networks();
 
 	</form>
 </div>
-
-<script>
-	jQuery(document).ready(function ($) {
-		$('.sortable').sortable();
-	});
-</script>

--- a/the-social-links.php
+++ b/the-social-links.php
@@ -11,7 +11,7 @@
  * Plugin Name: The Social Links
  * Plugin URI: https://github.com/seagyn/the-social-links
  * Description: The Social Links plugin adds a widget and shortcode to your WordPress website allowing you to display icons linking to your social profiles.
- * Version: 2.0.4
+ * Version: 2.0.5
  * Requires at least: 4.2
  * Requires PHP: 5.6
  * Author: Seagyn Davis
@@ -37,7 +37,7 @@
 
 namespace SeagynDavis\TheSocialLinks;
 
-define( 'THE_SOCIAL_LINKS_VERSION', '2.0.3' );
+define( 'THE_SOCIAL_LINKS_VERSION', '2.0.5' );
 define( 'THE_SOCIAL_LINKS_DIR', plugin_dir_path( __FILE__ ) );
 define( 'THE_SOCIAL_LINKS_URL', plugin_dir_url( __FILE__ ) );
 


### PR DESCRIPTION
Enqueue assets on the front end. It looks like this bug was introduced
in the 2.0 release. Prior to the version bump, [assets were being
enqueued] from the `admin_init` and `init` hooks. However, after the
update, [front end assets were no longer being enqueued].

This commit reimplements the original behavior so that assets are
enqueued on the front end. Additionally, this commit prefixes style and
script handles with `tsl`, and moves a bit of JavaScript out of a
template and into a dedicated file. In general, I tried to make
everything related to asset enqueuing as conventional and as possible.

[assets were being enqueued]: https://github.com/seagyn/the-social-links/blob/a3c4136e5f6294d886882ecde463ae996be6a838/the-social-links.php#L84-L85
[front end assets were no longer being enqueued]: https://github.com/seagyn/the-social-links/blob/afd7197c44a079af88c72cc82f58f56a4f2fdc63/src/boot.php#L49